### PR TITLE
fixes for LIBREELEC buildsystem building

### DIFF
--- a/cli/buildsystem/main.mk
+++ b/cli/buildsystem/main.mk
@@ -43,10 +43,6 @@ $(error no TARGETMK defined)
 endif
 include $(TARGETMK)
 
-ifeq ($(HOSTOS),LIBREELEC)
-MACHINE := Linux_aarch64
-endif
-
 # Add all the libraries defined in config.mk to LDLIBS
 LDLIBS := $(addprefix -l,$(LIBRARIES))
 ifeq ($(HOSTOS), win)

--- a/cli/buildsystem/main.mk
+++ b/cli/buildsystem/main.mk
@@ -69,7 +69,9 @@ LSEARCH := -L../libs/Pi_32
 endif
 endif
 
+ifneq ($(HOSTOS),LIBREELEC)
 LDFLAGS += -L/usr/local/lib
+endif
 
 # Build Directory
 BUILDDIR := $(BUILDDIR)/$(TARGET)/$(CONFIG)

--- a/cli/targets/flirc_util.mk
+++ b/cli/targets/flirc_util.mk
@@ -22,6 +22,8 @@ endif
 
 ifeq ($(HOSTOS),LINUX)
 LIBRARIES += hidapi-hidraw
+else ifeq ($(HOSTOS),LIBREELEC)
+LIBRARIES += hidapi-hidraw
 else ifeq ($(HOSTOS),win)
 LIBRARIES += hidapi ncurses
 else


### PR DESCRIPTION
I think these are all simple and shouldn't break normal flirc_util build targets. I need to run build testing before merge:

- [x] Linux_x86_64
- [x] Linux_arm
- [x] Linux_aarch64